### PR TITLE
Updated django_heroku to django_on_heroku

### DIFF
--- a/Django_Blog/13-Deployment-Heroku/django_project/django_project/settings.py
+++ b/Django_Blog/13-Deployment-Heroku/django_project/django_project/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
-import django_heroku
+import django_on_heroku
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -150,4 +150,4 @@ AWS_DEFAULT_ACL = None
 
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
-django_heroku.settings(locals())
+django_on_heroku.settings(locals())


### PR DESCRIPTION
Using django_heroku will cause an error since it has been deprecated. People should use django_on_heroku instead. Fixes #issue https://github.com/CoreyMSchafer/code_snippets/issues/165