### PR TITLE
Added django_on_heroku and psycopg2-binary dependencies

### DIFF
--- a/Django_Blog/13-Deployment-Heroku/django_project/requirements.txt
+++ b/Django_Blog/13-Deployment-Heroku/django_project/requirements.txt
@@ -5,14 +5,14 @@ chardet==3.0.4
 dj-database-url==0.5.0
 Django==2.1
 django-crispy-forms==1.7.2
-django-heroku==0.3.1
+django-on-heroku==1.1.2
 django-storages==1.7.1
 docutils==0.14
 gunicorn==19.9.0
 idna==2.7
 jmespath==0.9.3
 Pillow==5.2.0
-psycopg2==2.7.7
+psycopg2-binary==2.9.1
 python-dateutil==2.8.0
 pytz==2018.5
 requests==2.19.1


### PR DESCRIPTION
Changing django_heroku for django_on_heroku and adding both django-on-heroku==1.1.2 and psycopg2-binary==2.9.1 to the requirements.txt file Fixes #issue CoreyMSchafer#165